### PR TITLE
k8s.yaml: rely on more defaults and fix indentation

### DIFF
--- a/deployment_examples/k8s.yaml
+++ b/deployment_examples/k8s.yaml
@@ -27,7 +27,6 @@ spec:
       containers:
        - name: naemon-core
          image: op5com/merlin-naemon:latest
-         imagePullPolicy: Never
          resources:
          volumeMounts:
           - mountPath: /var/lib/merlin/
@@ -66,8 +65,7 @@ spec:
            value: ""
        - name: naemon-merlin
          image: op5com/merlin-merlind:latest
-         imagePullPolicy: Never
-        livenessProbe:
+         livenessProbe:
            exec:
              command:
              - /usr/bin/mon
@@ -84,4 +82,3 @@ spec:
             name: ipc
           - mountPath: /etc/merlin
             name: merlin-conf
-      restartPolicy: Always


### PR DESCRIPTION
Rely on the defaults values for: `imagePullPolicy` and `restartPolicy`.

Also fix an indentation issue.

Signed-off-by: Jacob Hansen <jhansen@op5.com>