### PR TITLE
Correct image in deployment examples

### DIFF
--- a/deployment_examples/docker-compose.yml
+++ b/deployment_examples/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.1"
 services:
-  naemon-core:
+  merlin-naemon:
     volumes:
       - ipc:/var/lib/merlin/
       - merlin_config:/etc/merlin/
@@ -13,13 +13,13 @@ services:
       POLLER_ADDRESS:
       POLLER_NAME:
       POLLER_HOSTGROUPS:
-      LOG_LEVEL: # debug, info (default), error, critical
+      LOG_LEVEL: "info" # debug, info (default), error, critical
       FILES_TO_SYNC:
-  naemon-merlin:
+  merlin-daemon:
     volumes:
       - ipc:/var/lib/merlin/
       - merlin_config:/etc/merlin/
-    image: op5com/merlin-merlind:latest
+    image: op5com/merlin-daemon:latest
 volumes:
   ipc:
   merlin_config:

--- a/deployment_examples/k8s.yaml
+++ b/deployment_examples/k8s.yaml
@@ -62,9 +62,9 @@ spec:
          - name: FILES_TO_SYNC
            value: ""
          - name: LOG_LEVEL
-           value: ""
+           value: "INFO"
        - name: naemon-merlin
-         image: op5com/merlin-merlind:latest
+         image: op5com/merlin-daemon:latest
          livenessProbe:
            exec:
              command:


### PR DESCRIPTION
The image for the merlin daemon was incorrectly named in the example
deployment files.

Further we set the log level to the default value, as an empty string
(""), are causing issue, and perhaps it can be confusing that you either
have to no set it at all, or set it to a valid value.

In docker-compose the containers have been renamed to match the images.